### PR TITLE
Update to CTFd 3.7.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.7.2@sha256:bb8077128668007e5130d37dbcd500b933cd449a4ae58fc327147f3811fbff7b
+        image: ctfd/ctfd:3.7.3@sha256:90470e1fe0f93028ce6ac197b8942916ee157d4b5d33c8266c5bec7662e55ac3
         ports:
           - 8000:8000
     steps:

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
 
 Golang client for interacting with [CTFd](https://ctfd.io/).
 
-Last version tested on: [3.7.2](https://github.com/CTFd/CTFd/releases/tag/3.7.2).
+Last version tested on: [3.7.3](https://github.com/CTFd/CTFd/releases/tag/3.7.3).

--- a/api/configs.go
+++ b/api/configs.go
@@ -28,6 +28,10 @@ type PatchConfigsParams struct {
 	ThemeHeader   *string `json:"theme_header,omitempty"`
 	ThemeSettings *string `json:"theme_settings,omitempty"`
 
+	// Localization
+
+	DefaultLocale *string `json:"default_locale,omitempty"`
+
 	// Accounts
 
 	DomainWhitelist            *string `json:"domain_whitelist,omitempty"`


### PR DESCRIPTION
This PR comes with the updates of CTFd 3.7.3 (see [changelog here](https://github.com/CTFd/CTFd/releases/tag/3.7.3)).

Once merged, will require a minor tag.