### PR TITLE
Function is not mandatory for all challenges, only dynamic ones

### DIFF
--- a/api/challenges.go
+++ b/api/challenges.go
@@ -27,7 +27,7 @@ type PostChallengesParams struct {
 	Category       string        `json:"category"`
 	Description    string        `json:"description"`
 	Attribution    *string       `json:"attribution,omitempty"`
-	Function       string        `json:"function"`
+	Function       *string       `json:"function,omitempty"`
 	ConnectionInfo *string       `json:"connection_info,omitempty"`
 	Value          int           `json:"value"`
 	Initial        *int          `json:"initial,omitempty"`
@@ -83,7 +83,7 @@ type PatchChallengeParams struct {
 	Category       string  `json:"category"`
 	Description    string  `json:"description"`
 	Attribution    *string `json:"attribution,omitempty"`
-	Function       string  `json:"function"`
+	Function       *string `json:"function,omitempty"`
 	ConnectionInfo *string `json:"connection_info,omitempty"`
 	Value          *int    `json:"value,omitempty"`
 	Initial        *int    `json:"initial,omitempty"`

--- a/api/model.go
+++ b/api/model.go
@@ -8,7 +8,7 @@ type (
 		Attribution    *string       `json:"attribution"`
 		ConnectionInfo *string       `json:"connection_info,omitempty"`
 		MaxAttempts    *int          `json:"max_attempts,omitempty"`
-		Function       string        `json:"function"`
+		Function       *string       `json:"function,omitempty"`
 		Value          int           `json:"value"`
 		Initial        *int          `json:"initial,omitempty"`
 		Decay          *int          `json:"decay,omitempty"`

--- a/api/run_test.go
+++ b/api/run_test.go
@@ -97,7 +97,7 @@ func Test_F_CTF(t *testing.T) {
 		Name:           "Stealing data",
 		Category:       "network",
 		Description:    "The network administrator just sent you the info that some strange packets where going out of a server.\nAt first glance, it is an internal one.\nCan you tell us what it is ?",
-		Function:       "logarithmic",
+		Function:       ptr("logarithmic"),
 		ConnectionInfo: ptr("ssh -l pandatix@master.pandatix.dev"),
 		MaxAttempts:    ptr(3),
 		Initial:        ptr(500),

--- a/api/setup_test.go
+++ b/api/setup_test.go
@@ -96,7 +96,7 @@ func Test_F_Setup(t *testing.T) {
 		Name:           "Stealing data",
 		Category:       "network",
 		Description:    "The network administrator just sent you the info that some strange packets where going out of a server.\nAt first glance, it is an internal one.\nCan you tell us what it is ?",
-		Function:       "logarithmic",
+		Function:       ptr("logarithmic"),
 		ConnectionInfo: ptr("ssh -l pandatix@master.pandatix.dev"),
 		MaxAttempts:    ptr(3),
 		Initial:        ptr(500),

--- a/examples/setup/main.go
+++ b/examples/setup/main.go
@@ -62,7 +62,7 @@ func main() {
 		Category:       "crypto",
 		Description:    "...",
 		Attribution:    ptr("pandatix"),
-		Function:       "logarithmic",
+		Function:       ptr("logarithmic"),
 		ConnectionInfo: ptr("ssh -l user@crypto1.ctfer.io"),
 		MaxAttempts:    ptr(3),
 		Initial:        ptr(500),


### PR DESCRIPTION
This PR solves #112.

I took the path of a small breaking change on `challenge.function` type to align with the remaining of the API, which could be criticized.

This would not require a major tag as it only affects a small portion of the API, neither a minor one as it does not affect the adjacent functionalities. A patch would be good imo.

I apologize in advance to anyone who went to this PR due to a dependency update that failed :face_with_open_eyes_and_hand_over_mouth: 
