### PR TITLE
Update CTFd to 3.7.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.7.4@sha256:b2cc1ff1767d919282cf9811ec41a9a4f994d502f502b4a8852999ffb1b7e81a
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
     steps:

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
 
 Golang client for interacting with [CTFd](https://ctfd.io/).
 
-Last version tested on: [3.7.4](https://github.com/CTFd/CTFd/releases/tag/3.7.4).
+Last version tested on: [3.7.5](https://github.com/CTFd/CTFd/releases/tag/3.7.5).

--- a/api/model.go
+++ b/api/model.go
@@ -5,7 +5,7 @@ type (
 		ID             int           `json:"id"`
 		Name           string        `json:"name"`
 		Description    string        `json:"description"`
-		Attribution    *string       `json:"attribution"`
+		Attribution    *string       `json:"attribution,omitempty"`
 		ConnectionInfo *string       `json:"connection_info,omitempty"`
 		MaxAttempts    *int          `json:"max_attempts,omitempty"`
 		Function       *string       `json:"function,omitempty"`


### PR DESCRIPTION
This PR updates CTFd to 3.7.5 after its recent release.

It should fix the `challenge.attribution` issue, so changes could be propagated to the TF provider.