### PR TITLE
feat: functional option to pass a transport (http.RoundTripper)

### DIFF
--- a/api/files.go
+++ b/api/files.go
@@ -87,7 +87,7 @@ func (client *Client) GetFileContent(file *File, opts ...Option) ([]byte, error)
 	}
 
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/files/%s", file.Location), nil)
-	req = applyOpts(req, opts...)
+	req, client.sub.Transport = applyOpts(req, opts...)
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/api/topics.go
+++ b/api/topics.go
@@ -52,7 +52,7 @@ type DeleteTopicArgs struct {
 func (client *Client) DeleteTopic(params *DeleteTopicArgs, opts ...Option) error {
 	// Build request
 	req, _ := http.NewRequest(http.MethodDelete, "/topics", nil)
-	req = applyOpts(req, opts...)
+	req, client.sub.Transport = applyOpts(req, opts...)
 
 	// Encode parameters
 	val := url.Values{}


### PR DESCRIPTION
In this PR, I propose to add a new functional option `WithTransport`.
It enables passing a Transport to use with the underlying client, which defaults to `http.DefaultTransport`.

For instance, we could pass an `otelhttp.NewTransport(...)` from [`go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/net/http/otelhttp) and propagate the OTEL bagage through the HTTP client, which could then be received by CTFd.