### PR TITLE
impr(api): add notification user and team ID for non-broadcast mode

### DIFF
--- a/api/notifications.go
+++ b/api/notifications.go
@@ -33,6 +33,8 @@ type PostNotificationsParams struct {
 	Sound   bool   `json:"sound"`
 	Title   string `json:"title"`
 	Type    string `json:"type"`
+	UserID  *int   `schema:"user_id,omitempty"`
+	TeamID  *int   `schema:"team_id,omitempty"`
 }
 
 func (client *Client) PostNotifications(params *PostNotificationsParams, opts ...Option) (*Notification, error) {


### PR DESCRIPTION
This PR adds the user and team IDs in the `(*Client).PostNotifications` method.
It allows non-broadcast notifications, for specific targets.

It is not documented, but viewing [code](https://github.com/CTFd/CTFd/blob/master/CTFd/models/__init__.py#L64-L65) it should work properly (especially since it is documented per GET/HEAD endpoints).